### PR TITLE
Use __has_attribute(unused) macro as a check

### DIFF
--- a/include/boost/concept/detail/general.hpp
+++ b/include/boost/concept/detail/general.hpp
@@ -67,10 +67,14 @@ struct requirement_<void(*)(Model)>
 
 // Version check from https://svn.boost.org/trac/boost/changeset/82886
 // (boost/static_assert.hpp)
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))) 
-#define BOOST_CONCEPT_UNUSED_TYPEDEF __attribute__((unused))
+#if defined(__has_attribute)
+#  if __has_attribute(unused)
+#     define BOOST_CONCEPT_UNUSED_TYPEDEF __attribute__((unused))
+#  endif
+#elif defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+#  define BOOST_CONCEPT_UNUSED_TYPEDEF __attribute__((unused))
 #else
-#define BOOST_CONCEPT_UNUSED_TYPEDEF /**/
+#  define BOOST_CONCEPT_UNUSED_TYPEDEF /**/
 #endif
 
 #  define BOOST_CONCEPT_ASSERT_FN( ModelFnPtr )             \


### PR DESCRIPTION
While currently the gcc marketing version number is used to check for
the __attribute__((unused)) feature of the language, clang has its "gcc
compatibility version number" set to 4.2, causing warnings to appear
when compiling with clang and -Wunused-local-typedefs

Using the __has_attribute(unused) macro will satisfy the clang
compiler, and is also supported in gcc starting with 5.0