### PR TITLE
Use BOOST_ATTRIBUTE_UNUSED from boost/config

### DIFF
--- a/include/boost/concept/detail/general.hpp
+++ b/include/boost/concept/detail/general.hpp
@@ -6,6 +6,7 @@
 
 # include <boost/preprocessor/cat.hpp>
 # include <boost/concept/detail/backward_compatibility.hpp>
+# include <boost/config/suffix.hpp>
 
 # ifdef BOOST_OLD_CONCEPT_SUPPORT
 #  include <boost/concept/detail/has_constraints.hpp>
@@ -65,19 +66,11 @@ struct requirement_<void(*)(Model)>
   
 # endif
 
-// Version check from https://svn.boost.org/trac/boost/changeset/82886
-// (boost/static_assert.hpp)
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))) 
-#define BOOST_CONCEPT_UNUSED_TYPEDEF __attribute__((unused))
-#else
-#define BOOST_CONCEPT_UNUSED_TYPEDEF /**/
-#endif
-
 #  define BOOST_CONCEPT_ASSERT_FN( ModelFnPtr )             \
     typedef ::boost::concepts::detail::instantiate<          \
     &::boost::concepts::requirement_<ModelFnPtr>::failed>    \
       BOOST_PP_CAT(boost_concept_check,__LINE__)             \
-      BOOST_CONCEPT_UNUSED_TYPEDEF
+      BOOST_ATTRIBUTE_UNUSED
 
 }}
 


### PR DESCRIPTION
This macro does the proper version check and works against clang 3.6 (which otherwise spits warnings).

I haven't tested this patch. If someone could do it, I would be grateful, otherwise I'll do it myself later.