### PR TITLE
Get rid of iterator.hpp

### DIFF
--- a/include/boost/concept_archetype.hpp
+++ b/include/boost/concept_archetype.hpp
@@ -15,9 +15,10 @@
 #define BOOST_CONCEPT_ARCHETYPES_HPP
 
 #include <boost/config.hpp>
-#include <boost/iterator.hpp>
 #include <boost/mpl/identity.hpp>
 #include <functional>
+#include <iterator>  // iterator tags
+#include <cstddef>   // std::ptrdiff_t
 
 namespace boost {
 


### PR DESCRIPTION
It does nothing more than pulling 'std::iterator' into namespace boost and including standard libraries 'iterator' and 'cstddef'. This library only takes advantage of the included headers. OTOH, pulling 'std::iterator' into boost generates deprecation warnings in MSVC 14.1 when compiling in C++17 mode. Besides that, Boost's 'iterator.hpp' is deprecated, too.

Signed-off-by: Daniela Engert <dani@ngrt.de>