### PR TITLE
Drop dependency on Boost.Mpl

### DIFF
--- a/include/boost/concept/assert.hpp
+++ b/include/boost/concept/assert.hpp
@@ -5,7 +5,7 @@
 # define BOOST_CONCEPT_ASSERT_DWA2006430_HPP
 
 # include <boost/config.hpp>
-# include <boost/detail/workaround.hpp>
+# include <boost/config/workaround.hpp>
 
 // The old protocol used a constraints() member function in concept
 // checking classes.  If the compiler supports SFINAE, we can detect

--- a/include/boost/concept/detail/general.hpp
+++ b/include/boost/concept/detail/general.hpp
@@ -10,7 +10,7 @@
 
 # ifdef BOOST_OLD_CONCEPT_SUPPORT
 #  include <boost/concept/detail/has_constraints.hpp>
-#  include <boost/mpl/if.hpp>
+#  include <boost/type_traits/conditional.hpp>
 # endif
 
 // This implementation works on Comeau and GCC, all the way back to
@@ -49,8 +49,8 @@ struct constraint
   
 template <class Model>
 struct requirement_<void(*)(Model)>
-  : mpl::if_<
-        concepts::not_satisfied<Model>
+  : boost::conditional<
+        concepts::not_satisfied<Model>::value
       , constraint<Model>
       , requirement<failed ************ Model::************>
     >::type

--- a/include/boost/concept/detail/has_constraints.hpp
+++ b/include/boost/concept/detail/has_constraints.hpp
@@ -4,8 +4,8 @@
 #ifndef BOOST_CONCEPT_DETAIL_HAS_CONSTRAINTS_DWA2006429_HPP
 # define BOOST_CONCEPT_DETAIL_HAS_CONSTRAINTS_DWA2006429_HPP
 
-# include <boost/mpl/bool.hpp>
-# include <boost/detail/workaround.hpp>
+# include <boost/type_traits/integral_constant.hpp>
+# include <boost/config/workaround.hpp>
 # include <boost/concept/detail/backward_compatibility.hpp>
 
 namespace boost { namespace concepts {
@@ -42,7 +42,7 @@ struct not_satisfied
     BOOST_STATIC_CONSTANT(
         bool
       , value = sizeof( detail::has_constraints_((Model*)0) ) == sizeof(detail::yes) );
-    typedef mpl::bool_<value> type;
+    typedef boost::integral_constant<bool, value> type;
 };
 
 }} // namespace boost::concepts::detail

--- a/include/boost/concept/detail/msvc.hpp
+++ b/include/boost/concept/detail/msvc.hpp
@@ -10,7 +10,7 @@
 
 # ifdef BOOST_OLD_CONCEPT_SUPPORT
 #  include <boost/concept/detail/has_constraints.hpp>
-#  include <boost/mpl/if.hpp>
+#  include <boost/type_traits/conditional.hpp>
 # endif
 
 # ifdef BOOST_MSVC
@@ -54,7 +54,7 @@ namespace detail
 
 template <class Model>
 struct require
-  : mpl::if_c<
+  : boost::conditional<
         not_satisfied<Model>::value
       , detail::constraint
 # ifndef BOOST_NO_PARTIAL_SPECIALIZATION

--- a/include/boost/concept/usage.hpp
+++ b/include/boost/concept/usage.hpp
@@ -5,7 +5,7 @@
 # define BOOST_CONCEPT_USAGE_DWA2006919_HPP
 
 # include <boost/concept/assert.hpp>
-# include <boost/detail/workaround.hpp>
+# include <boost/config/workaround.hpp>
 # include <boost/concept/detail/backward_compatibility.hpp>
 
 namespace boost { namespace concepts { 

--- a/include/boost/concept_archetype.hpp
+++ b/include/boost/concept_archetype.hpp
@@ -15,7 +15,6 @@
 #define BOOST_CONCEPT_ARCHETYPES_HPP
 
 #include <boost/config.hpp>
-#include <boost/mpl/identity.hpp>
 #include <functional>
 #include <iterator>  // iterator tags
 #include <cstddef>   // std::ptrdiff_t

--- a/include/boost/concept_check.hpp
+++ b/include/boost/concept_check.hpp
@@ -24,9 +24,9 @@
 # include <utility>
 # include <boost/type_traits/is_same.hpp>
 # include <boost/type_traits/is_void.hpp>
-# include <boost/mpl/assert.hpp>
-# include <boost/mpl/bool.hpp>
-# include <boost/detail/workaround.hpp>
+# include <boost/static_assert.hpp>
+# include <boost/type_traits/integral_constant.hpp>
+# include <boost/config/workaround.hpp>
 
 # include <boost/concept/usage.hpp>
 # include <boost/concept/detail/concept_def.hpp>
@@ -301,14 +301,14 @@ namespace boost
       BOOST_CONCEPT_USAGE(Generator) { test(is_void<Return>()); }
 
    private:
-      void test(boost::mpl::false_)
+      void test(boost::false_type)
       {
           // Do we really want a reference here?
           const Return& r = f();
           ignore_unused_variable_warning(r);
       }
 
-      void test(boost::mpl::true_)
+      void test(boost::true_type)
       {
           f();
       }
@@ -321,14 +321,14 @@ namespace boost
       BOOST_CONCEPT_USAGE(UnaryFunction) { test(is_void<Return>()); }
 
    private:
-      void test(boost::mpl::false_)
+      void test(boost::false_type)
       {
           f(arg);               // "priming the pump" this way keeps msvc6 happy (ICE)
           Return r = f(arg);
           ignore_unused_variable_warning(r);
       }
 
-      void test(boost::mpl::true_)
+      void test(boost::true_type)
       {
           f(arg);
       }
@@ -350,14 +350,14 @@ namespace boost
   {
       BOOST_CONCEPT_USAGE(BinaryFunction) { test(is_void<Return>()); }
    private:
-      void test(boost::mpl::false_)
+      void test(boost::false_type)
       {
           f(first,second);
           Return r = f(first, second); // require operator()
           (void)r;
       }
 
-      void test(boost::mpl::true_)
+      void test(boost::true_type)
       {
           f(first,second);
       }
@@ -966,7 +966,7 @@ namespace boost
       {
           typedef typename C::key_type key_type;
           typedef typename C::value_type value_type;
-          BOOST_MPL_ASSERT((boost::is_same<key_type,value_type>));
+          BOOST_STATIC_ASSERT((boost::is_same<key_type,value_type>::value));
       }
   };
 
@@ -979,7 +979,7 @@ namespace boost
           typedef typename C::value_type value_type;
           typedef typename C::mapped_type mapped_type;
           typedef std::pair<const key_type, mapped_type> required_value_type;
-          BOOST_MPL_ASSERT((boost::is_same<value_type,required_value_type>));
+          BOOST_STATIC_ASSERT((boost::is_same<value_type,required_value_type>::value));
       }
   };
 

--- a/include/boost/concept_check/general.hpp
+++ b/include/boost/concept_check/general.hpp
@@ -6,7 +6,7 @@
 
 # ifdef BOOST_OLD_CONCEPT_SUPPORT
 #  include <boost/concept_check/has_constraints.hpp>
-#  include <boost/mpl/if.hpp>
+#  include <boost/type_traits/conditional.hpp>
 # endif
 
 
@@ -54,7 +54,7 @@ namespace boost
   
   template <class Model>
   struct concept_check_<void(*)(Model)>
-    : mpl::if_c<
+    : conditional<
           concept_checking::has_constraints<Model>::value
         , constraint_check<Model>
         , concept_check<Model>

--- a/include/boost/concept_check/msvc.hpp
+++ b/include/boost/concept_check/msvc.hpp
@@ -6,7 +6,7 @@
 
 # ifdef BOOST_OLD_CONCEPT_SUPPORT
 #  include <boost/concept_check/has_constraints.hpp>
-#  include <boost/mpl/if.hpp>
+#  include <boost/type_traits/conditional.hpp>
 # endif
 
 
@@ -40,7 +40,7 @@ namespace boost
 
   template <class Model>
   struct concept_check
-    : mpl::if_c<
+    : conditional<
           concept_checking::has_constraints<Model>::value
         , concept_checking::constraint_check<Model>
         , concept_checking::concept_check_<Model>


### PR DESCRIPTION
From the dependency [report](https://pdimov.github.io/boostdep-report/develop/module-levels.html), ConceptCheck is currently level 7 because Mpl is level 6. With this change, it moves up to level 3.