### PR TITLE
Fix broken links in documentation.

### DIFF
--- a/concept_check.htm
+++ b/concept_check.htm
@@ -220,7 +220,7 @@ bad_error_eg.cpp:8:   instantiated from here
 
   <p>In this case, the fundamental error is
   that <tt>std:complex&lt;float&gt;</tt> does not model the <a href=
-  "http://www.sgi.com/tech/stl/LessThanComparable.html">LessThanComparable</a>
+  "http://www.boost.org/sgi/stl/LessThanComparable.html">LessThanComparable</a>
   concept.  Unfortunately, there is nothing in the error message to
   indicate that to the user.</p>
 
@@ -232,7 +232,7 @@ bad_error_eg.cpp:8:   instantiated from here
   <ol>
     <li>There is no textual correlation between the error message and the
     documented requirements for <tt>std::stable_sort()</tt> and for <a href=
-    "http://www.sgi.com/tech/stl/LessThanComparable.html">LessThanComparable</a>.</li>
+    "http://www.boost.org/sgi/stl/LessThanComparable.html">LessThanComparable</a>.</li>
 
     <li>The error message is overly long, listing functions internal
     to the STL (e.g. <code>__insertion_sort</code>) that the user
@@ -268,7 +268,7 @@ boost/concept_check.hpp:236: error: no match for ‘operator&lt;’ in ‘((boos
   <ul>
     <li>The message refers explicitly to concepts that the user can look up
     in the STL documentation (<a href=
-    "http://www.sgi.com/tech/stl/LessThanComparable.html">LessThanComparable</a>).</li>
+    "http://www.boost.org/sgi/stl/LessThanComparable.html">LessThanComparable</a>).</li>
 
     <li>The error message is now much shorter and does not reveal
     internal STL functions, nor indeed does it even point

--- a/concept_covering.htm
+++ b/concept_covering.htm
@@ -35,7 +35,7 @@
   test program can then be compiled with the archetype classes as the inputs
   to the component. If the program compiles then one can be sure that the
   concepts cover the component. The following code shows the archetype class
-  for the <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input
+  for the <a href="http://www.boost.org/sgi/stl/InputIterator.html">Input
   Iterator</a> concept. Some care must be taken to ensure that the archetype
   is an exact match to the concept. For example, the concept states that the
   return type of <tt>operator*()</tt> must be convertible to the value type.
@@ -86,7 +86,7 @@ public:
   "./stl_concept_covering.cpp"><tt>stl_concept_covering.cpp</tt></a> that
   shows how archetypes can be used to check the requirement documentation for
   <a href=
-  "http://www.sgi.com/tech/stl/stable_sort.html"><tt>std::stable_sort()</tt></a>.
+  "http://www.boost.org/sgi/stl/stable_sort.html"><tt>std::stable_sort()</tt></a>.
   In this case, it looks like the <a href=
   "../utility/CopyConstructible.html">CopyConstructible</a> and <a href=
   "../utility/Assignable.html">Assignable</a> requirements were forgotten in

--- a/creating_concepts.htm
+++ b/creating_concepts.htm
@@ -26,7 +26,7 @@
 
   <p>As an example of how to create a concept checking class template, we
   look at how to create the corresponding checks for the <a href=
-  "http://www.sgi.com/tech/stl/InputIterator.html">InputIterator</a> concept.
+  "http://www.boost.org/sgi/stl/InputIterator.html">InputIterator</a> concept.
   The complete definition is here:</p>
   <pre>
 template &lt;class X&gt;

--- a/implementation.htm
+++ b/implementation.htm
@@ -104,7 +104,7 @@
   checks, we wrap the member function pointer mechanism in a function named
   <tt>function_requires()</tt>. The following code snippet shows how to use
   <tt>function_requires()</tt> to make sure that the iterator is a <a href=
-  "http://www.sgi.com/tech/stl/RandomAccessIterator.html">RandomAccessIterator</a>.</p>
+  "http://www.boost.org/sgi/stl/RandomAccessIterator.html">RandomAccessIterator</a>.</p>
   <pre>
   template &lt;class Iter&gt;
   void stable_sort(Iter first, Iter last)

--- a/prog_with_concepts.htm
+++ b/prog_with_concepts.htm
@@ -60,7 +60,7 @@ in the concept.
 For example, the
 <tt>std::stable_sort()</tt> function requires that the value type of
 the iterator be <a
-href="http://www.sgi.com/tech/stl/LessThanComparable.html">
+href="http://www.boost.org/sgi/stl/LessThanComparable.html">
 LessThanComparable</a>, which not only
 includes <tt>operator&lt;()</tt>, but also <tt>operator&gt;()</tt>,
 <tt>operator&lt;=()</tt>, and <tt>operator&gt;=()</tt>.  
@@ -68,19 +68,19 @@ It turns out that <tt>std::stable_sort()</tt> only uses
 <tt>operator&lt;()</tt>.  The question then arises: should 
 <tt>std::stable_sort()</tt> be specified in terms of the concept
 <a
-href="http://www.sgi.com/tech/stl/LessThanComparable.html">
+href="http://www.boost.org/sgi/stl/LessThanComparable.html">
 LessThanComparable</a> or in terms of a concept that only
 requires <tt>operator&lt;()</tt>?
 
 <p>
 We remark first that the use of <a
-href="http://www.sgi.com/tech/stl/LessThanComparable.html">
+href="http://www.boost.org/sgi/stl/LessThanComparable.html">
 LessThanComparable</a> does not really violate the requirement
 minimization principle because all of the other operators can be
 trivially implemented in terms of <tt>operator&lt;()</tt>. By
 ``trivial'' we mean one line of code and a constant run-time cost.  
 More fundamentally, however, the use of <a
-href="http://www.sgi.com/tech/stl/LessThanComparable.html">
+href="http://www.boost.org/sgi/stl/LessThanComparable.html">
 LessThanComparable</a> does not violate the requirement minimization
 principle because all of the comparison operators (<tt>&lt;</tt>,
 <tt>></tt>, <tt><=</tt>, <tt>>=</tt>) are conceptually equivalent (in
@@ -98,7 +98,7 @@ implementation in places to use <tt>operator>()</tt> instead of
 requirements are part of the public interface, such a change could
 potentially break client code.  If instead
 <a
-href="http://www.sgi.com/tech/stl/LessThanComparable.html">
+href="http://www.boost.org/sgi/stl/LessThanComparable.html">
 LessThanComparable</a> is given as the requirement for
 <tt>std::stable_sort()</tt>, then the maintainer is given a reasonable
 amount of flexibility within which to work.
@@ -110,9 +110,9 @@ amount of flexibility within which to work.
   basic containers, requiring traversal in a single direction is a smaller
   requirement than requiring traversal in both directions (hence the
   distinction between <a href=
-  "http://www.sgi.com/tech/stl/ForwardIterator.html">ForwardIterator</a> and
+  "http://www.boost.org/sgi/stl/ForwardIterator.html">ForwardIterator</a> and
   <a href=
-  "http://www.sgi.com/tech/stl/BidirectionalIterator.html">BidirectionalIterator</a>).
+  "http://www.boost.org/sgi/stl/BidirectionalIterator.html">BidirectionalIterator</a>).
   The semantic difference can be easily seen in the difference between the
   set of concrete data structures that have forward iterators versus the set
   that has bidirectional iterators. For example, singly-linked lists would

--- a/reference.htm
+++ b/reference.htm
@@ -106,11 +106,11 @@ struct <a href=
 
 template &lt;class T&gt;
 struct SGI<a href=
-"http://www.sgi.com/tech/stl/Assignable.html">Assignable</a>;
+"http://www.boost.org/sgi/stl/Assignable.html">Assignable</a>;
 
 template &lt;class T&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/DefaultConstructible.html">DefaultConstructible</a>;
+"http://www.boost.org/sgi/stl/DefaultConstructible.html">DefaultConstructible</a>;
 
 template &lt;class T&gt; 
 struct <a href=
@@ -118,7 +118,7 @@ struct <a href=
 
 template &lt;class T&gt; 
 struct <a href=
-"http://www.sgi.com/tech/stl/EqualityComparable.html">EqualityComparable</a>; // Standard ref 20.1.1
+"http://www.boost.org/sgi/stl/EqualityComparable.html">EqualityComparable</a>; // Standard ref 20.1.1
 
 template &lt;class T&gt;
 struct <a href=
@@ -126,7 +126,7 @@ struct <a href=
 
 template &lt;class T&gt;
 struct Comparable; // The SGI STL <a href=
-"http://www.sgi.com/tech/stl/LessThanComparable.html">LessThanComparable</a> concept
+"http://www.boost.org/sgi/stl/LessThanComparable.html">LessThanComparable</a> concept
 </pre>
 
   <h3><a name="iterator-concepts" id="iterator-concepts">Iterator Concept
@@ -134,29 +134,29 @@ struct Comparable; // The SGI STL <a href=
   <pre>
 template &lt;class Iter&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/InputIterator.html">InputIterator</a>; // Standard ref 24.1.1 Table 72
+"http://www.boost.org/sgi/stl/InputIterator.html">InputIterator</a>; // Standard ref 24.1.1 Table 72
 
 template &lt;class Iter, class T&gt; 
 struct <a href=
-"http://www.sgi.com/tech/stl/OutputIterator.html">OutputIterator</a>; // Standard ref 24.1.2 Table 73
+"http://www.boost.org/sgi/stl/OutputIterator.html">OutputIterator</a>; // Standard ref 24.1.2 Table 73
 
 template &lt;class Iter&gt; 
 struct <a href=
-"http://www.sgi.com/tech/stl/ForwardIterator.html">ForwardIterator</a>; // Standard ref 24.1.3 Table 74
+"http://www.boost.org/sgi/stl/ForwardIterator.html">ForwardIterator</a>; // Standard ref 24.1.3 Table 74
 
 template &lt;class Iter&gt; 
 struct Mutable_ForwardIterator;
 
 template &lt;class Iter&gt; 
 struct <a href=
-"http://www.sgi.com/tech/stl/BidirectionalIterator.html">BidirectionalIterator</a>; // Standard ref 24.1.4 Table 75
+"http://www.boost.org/sgi/stl/BidirectionalIterator.html">BidirectionalIterator</a>; // Standard ref 24.1.4 Table 75
 
 template &lt;class Iter&gt; 
 struct Mutable_BidirectionalIterator;
 
 template &lt;class Iter&gt; 
 struct <a href=
-"http://www.sgi.com/tech/stl/RandomAccessIterator.html">RandomAccessIterator</a>; // Standard ref 24.1.5 Table 76
+"http://www.boost.org/sgi/stl/RandomAccessIterator.html">RandomAccessIterator</a>; // Standard ref 24.1.5 Table 76
 
 template &lt;class Iter&gt; 
 struct Mutable_RandomAccessIterator;
@@ -169,46 +169,46 @@ struct Mutable_RandomAccessIterator;
 #include "boost/concept_check.hpp"
 
 template &lt;class Func, class Return&gt;
-struct <a href="http://www.sgi.com/tech/stl/Generator.html">Generator</a>;
+struct <a href="http://www.boost.org/sgi/stl/Generator.html">Generator</a>;
 
 template &lt;class Func, class Return, class Arg&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/UnaryFunction.html">UnaryFunction</a>;
+"http://www.boost.org/sgi/stl/UnaryFunction.html">UnaryFunction</a>;
 
 template &lt;class Func, class Return, class First, class Second&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/BinaryFunction.html">BinaryFunction</a>;
+"http://www.boost.org/sgi/stl/BinaryFunction.html">BinaryFunction</a>;
 
 template &lt;class Func, class Arg&gt;
 struct Unary<a href=
-"http://www.sgi.com/tech/stl/Predicate.html">Predicate</a>;
+"http://www.boost.org/sgi/stl/Predicate.html">Predicate</a>;
 
 template &lt;class Func, class First, class Second&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/BinaryPredicate.html">BinaryPredicate</a>;
+"http://www.boost.org/sgi/stl/BinaryPredicate.html">BinaryPredicate</a>;
 
 template &lt;class Func, class First, class Second&gt;
 struct Const_BinaryPredicate;
 
 template &lt;class Func, class Return&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/AdaptableGenerator.html">AdaptableGenerator</a>;
+"http://www.boost.org/sgi/stl/AdaptableGenerator.html">AdaptableGenerator</a>;
 
 template &lt;class Func, class Return, class Arg&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/AdaptableUnaryFunction.html">AdaptableUnaryFunction</a>;
+"http://www.boost.org/sgi/stl/AdaptableUnaryFunction.html">AdaptableUnaryFunction</a>;
 
 template &lt;class Func, class First, class Second&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/AdaptableBinaryFunction.html">AdaptableBinaryFunction</a>;
+"http://www.boost.org/sgi/stl/AdaptableBinaryFunction.html">AdaptableBinaryFunction</a>;
 
 template &lt;class Func, class Arg&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/AdaptablePredicate.html">AdaptablePredicate</a>;
+"http://www.boost.org/sgi/stl/AdaptablePredicate.html">AdaptablePredicate</a>;
 
 template &lt;class Func, class First, class Second&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/AdaptableBinaryPredicate.html">AdaptableBinaryPredicate</a>;
+"http://www.boost.org/sgi/stl/AdaptableBinaryPredicate.html">AdaptableBinaryPredicate</a>;
 </pre>
 
   <h3><a name="container-concepts" id="container-concepts">Container Concept
@@ -218,67 +218,67 @@ struct <a href=
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/Container.html">Container</a>; // Standard ref 23.1 Table 65
+"http://www.boost.org/sgi/stl/Container.html">Container</a>; // Standard ref 23.1 Table 65
 
 template &lt;class C&gt;
 struct Mutable_Container;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/ForwardContainer.html">ForwardContainer</a>;
+"http://www.boost.org/sgi/stl/ForwardContainer.html">ForwardContainer</a>;
 
 template &lt;class C&gt;
 struct Mutable_ForwardContainer;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/ReversibleContainer.html">ReversibleContainer</a>; // Standard ref 23.1 Table 66
+"http://www.boost.org/sgi/stl/ReversibleContainer.html">ReversibleContainer</a>; // Standard ref 23.1 Table 66
 
 template &lt;class C&gt;
 struct Mutable_ReversibleContainer;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/RandomAccessContainer.html">RandomAccessContainer</a>;
+"http://www.boost.org/sgi/stl/RandomAccessContainer.html">RandomAccessContainer</a>;
 
 template &lt;class C&gt;
 struct Mutable_RandomAccessContainer;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/Sequence.html">Sequence</a>; // Standard ref 23.1.1
+"http://www.boost.org/sgi/stl/Sequence.html">Sequence</a>; // Standard ref 23.1.1
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/FrontInsertionSequence.html">FrontInsertionSequence</a>;
+"http://www.boost.org/sgi/stl/FrontInsertionSequence.html">FrontInsertionSequence</a>;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/BackInsertionSequence.html">BackInsertionSequence</a>;
+"http://www.boost.org/sgi/stl/BackInsertionSequence.html">BackInsertionSequence</a>;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/AssociativeContainer.html">AssociativeContainer</a>; // Standard ref 23.1.2 Table 69
+"http://www.boost.org/sgi/stl/AssociativeContainer.html">AssociativeContainer</a>; // Standard ref 23.1.2 Table 69
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/UniqueAssociativeContainer.html">UniqueAssociativeContainer</a>;
+"http://www.boost.org/sgi/stl/UniqueAssociativeContainer.html">UniqueAssociativeContainer</a>;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/MultipleAssociativeContainer.html">MultipleAssociativeContainer</a>;
+"http://www.boost.org/sgi/stl/MultipleAssociativeContainer.html">MultipleAssociativeContainer</a>;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/SimpleAssociativeContainer.html">SimpleAssociativeContainer</a>;
+"http://www.boost.org/sgi/stl/SimpleAssociativeContainer.html">SimpleAssociativeContainer</a>;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/PairAssociativeContainer.html">PairAssociativeContainer</a>;
+"http://www.boost.org/sgi/stl/PairAssociativeContainer.html">PairAssociativeContainer</a>;
 
 template &lt;class C&gt;
 struct <a href=
-"http://www.sgi.com/tech/stl/SortedAssociativeContainer.html">SortedAssociativeContainer</a>;
+"http://www.boost.org/sgi/stl/SortedAssociativeContainer.html">SortedAssociativeContainer</a>;
 
 template &lt;class C&gt;
 struct <a href=

--- a/using_concept_check.htm
+++ b/using_concept_check.htm
@@ -43,7 +43,7 @@
   <tt>EqualityComparableConcept</tt> class. The class corresponds to the
   EqualityComparable requirements described in 20.1.1 of the C++ Standard,
   and to the <a href=
-  "http://www.sgi.com/tech/stl/EqualityComparable.html">EqualityComparable</a>
+  "http://www.boost.org/sgi/stl/EqualityComparable.html">EqualityComparable</a>
   concept documented in the SGI STL.</p>
   <pre>
 template &lt;class T&gt;


### PR DESCRIPTION
Some documentation links currently point to pages that HP retired along with the rest of the SGI STL website. These links now point to the Boost mirror site.