### PR TITLE
Ignore unused variable in test (fix matrix warning)

### DIFF
--- a/test/usage_fail.cpp
+++ b/test/usage_fail.cpp
@@ -3,6 +3,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/concept/usage.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 template <class T>
 struct StringInitializable
@@ -11,6 +12,7 @@ struct StringInitializable
     BOOST_CONCEPT_USAGE(StringInitializable)
     {
         T x = "foo";
+        boost::ignore_unused(x);
     }
 };
 


### PR DESCRIPTION
See:

https://www.boost.org/development/tests/develop/output/teeks99-02-dg8-2a-Docker-64on64-concept_check-gcc-8~c++2a-warnings.html#usage_fail