### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/concept/assert.hpp
+++ b/include/boost/concept/assert.hpp
@@ -29,7 +29,7 @@
 
 # ifdef BOOST_MSVC
 #  include <boost/concept/detail/msvc.hpp>
-# elif BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+# elif BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  include <boost/concept/detail/borland.hpp>
 # else 
 #  include <boost/concept/detail/general.hpp>

--- a/include/boost/concept/requires.hpp
+++ b/include/boost/concept/requires.hpp
@@ -65,7 +65,7 @@ struct Requires_ : ::boost::ccheck_aux::unaryfunptr_arg_type<Result>
 # define BOOST_CONCEPT_REQUIRES(models, result)                                    \
     typename ::boost::ccheck_aux::unaryfunptr_arg_type<void(*)result>::type
 
-#elif BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#elif BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 
 // Same thing as below without the initial typename
 # define BOOST_CONCEPT_REQUIRES(models, result)                                \

--- a/include/boost/concept_archetype.hpp
+++ b/include/boost/concept_archetype.hpp
@@ -57,7 +57,7 @@ namespace boost {
   public:
       static T& get()
       {
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
           return *reinterpret_cast<T*>(0);
 #else 
           static char d[sizeof(T)];

--- a/test/stl_concept_covering.cpp
+++ b/test/stl_concept_covering.cpp
@@ -379,7 +379,7 @@ main()
     convertible_to_archetype<FT> value(dummy_cons);
     std::replace_if(fi, fi, pred, value);
   }
-#if !defined(BOOST_MSVC) || BOOST_WORKAROUND(BOOST_MSVC, > 1900)
+#if (!defined(BOOST_MSVC) || BOOST_WORKAROUND(BOOST_MSVC, > 1900)) && !defined(BOOST_EMBTC)
   // fails on MSVC 2015 and earlier
   {
     // Issue, the use of ?: inside replace_copy() complicates things
@@ -548,7 +548,7 @@ main()
     unary_predicate_archetype<PredArg> pred(dummy_cons);
     bi = std::partition(bi, bi, pred);
   }
-#ifndef BOOST_MSVC
+#if !defined(BOOST_MSVC) && !defined(BOOST_EMBTC)
   {
     // fails on MSVC
     typedef null_archetype<> PredArg;


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.