### PR TITLE
Remove usage of deprecated header boost/detail/iterator.hpp

### DIFF
--- a/test/fake_sort.hpp
+++ b/test/fake_sort.hpp
@@ -4,7 +4,7 @@
 #ifndef BOOST_LIBS_CONCEPT_CHECK_FAKE_SORT_DWA2006430_HPP
 # define BOOST_LIBS_CONCEPT_CHECK_FAKE_SORT_DWA2006430_HPP
 
-# include <boost/detail/iterator.hpp>
+# include <iterator>
 # include <boost/concept/requires.hpp>
 # include <boost/concept_check.hpp>
 


### PR DESCRIPTION
This header was deprecated in favor of `<iterator>`. It generates compiler warnings and will be removed in a future release.