### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,5 @@ target_include_directories(boost_concept_check INTERFACE include)
 target_link_libraries(boost_concept_check INTERFACE
     Boost::config
     Boost::preprocessor
-    Boost::static_assert
     Boost::type_traits
 )

--- a/build.jam
+++ b/build.jam
@@ -8,7 +8,6 @@ require-b2 5.2 ;
 constant boost_dependencies :
     /boost/config//boost_config
     /boost/preprocessor//boost_preprocessor
-    /boost/static_assert//boost_static_assert
     /boost/type_traits//boost_type_traits ;
 
 project /boost/concept_check


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.